### PR TITLE
handles the case of consecutive arabic numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,18 @@
 
 한글 <-> 숫자 변환 라이브러리
 
+* 기존 [WieeRd의 라이브러리](https://github.com/WieeRd/KoreanNumber)에서 숫자가 연속해서 나오는 경우의 처리를 추가한 버전
+
 ## Number -> Korean
 
 ```python
 
-import num2kr
+from num2kr import num2kr
 
 # num = int(input("Integer: "))
 num = 12345678
-print(num2kr.num2kr(num)) # same as num2kr(num, 0)
-print(num2kr.num2kr(num, 1))
+print(num2kr(num)) # same as num2kr(num, 0)
+print(num2kr(num, 1))
 
 # >>> 1234만 5678
 # >>> 일천이백삼십사만오천육백칠십팔
@@ -22,13 +24,18 @@ print(num2kr.num2kr(num, 1))
 
 ```python
 
-import kr2num
+from kr2num import kr2num
 
 # kr_str = input("Korean: ")
 kr_str = "일조삼천육백칠십일억이천구백삼십칠만사천오백십일"
-print(kr2num.kr2num(kr_str))
+print(kr2num(kr_str))
 
 # >>> 1367129374511
+
+kr_str = "22억1526만오천6백31"
+print(kr2num(kr_str))
+
+# >>> 2215265631
 
 ```
 
@@ -37,3 +44,5 @@ print(kr2num.kr2num(kr_str))
 
 kr2num: forked from https://github.com/codertimo/korean2num  
 num2kr: inspired by https://m.blog.naver.com/wideeyed/221771836059
+
+KoreanNumber: forked from https://github.com/WieeRd/KoreanNumber


### PR DESCRIPTION
기존에 처리되지 않던 "12만2천" 처럼 숫자가 연속해서 나오는 케이스에 대한 처리 로직 추가

처리 방법:
decode_result를 만들 때 [(12, False), (10000, True)] 처럼 연속된 숫자를 한꺼번에 리스트에 넣어 처리

그리고 이 경우를 처리하기 위해 만들어진 것으로 보이는 코드 삭제